### PR TITLE
feat(platforms): enable web platform support

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,10 +9,9 @@ analyzer:
 
     - test/**/*.g.dart
     - test/**/*.reflectable.dart
+    - test/**/*.mocks.dart
 
     - tool/**/*.g.dart
-  strong-mode:
-    implicit-casts: false
 
   # enable-experiment:
   #  - non-nullable

--- a/lib/transactions/sender/tx_sender.dart
+++ b/lib/transactions/sender/tx_sender.dart
@@ -1,6 +1,7 @@
 import 'package:alan/alan.dart';
 import 'package:alan/proto/cosmos/tx/v1beta1/export.dart' as tx;
-import 'package:grpc/grpc.dart';
+import 'package:grpc/src/client/channel.dart' as CC;
+import 'package:grpc/grpc_or_grpcweb.dart';
 
 /// Allows to easily send a [StdTx] using the data contained inside the
 /// specified [Wallet].
@@ -10,8 +11,9 @@ class TxSender {
   TxSender({required tx.ServiceClient client}) : _client = client;
 
   /// Builds a new [TxSender] given a [ClientChannel].
-  factory TxSender.build(ClientChannel channel) {
-    return TxSender(client: tx.ServiceClient(channel));
+  factory TxSender.build(GrpcOrGrpcWebClientChannel channel) {
+    CC.ClientChannel cc = channel as CC.ClientChannel; 
+    return TxSender(client: tx.ServiceClient(cc));
   }
 
   /// Builds a new [TxSender] from the given [NetworkInfo].

--- a/lib/transactions/sender/tx_sender.dart
+++ b/lib/transactions/sender/tx_sender.dart
@@ -1,6 +1,5 @@
 import 'package:alan/alan.dart';
 import 'package:alan/proto/cosmos/tx/v1beta1/export.dart' as tx;
-import 'package:grpc/src/client/channel.dart' as CC;
 import 'package:grpc/grpc_or_grpcweb.dart';
 
 /// Allows to easily send a [StdTx] using the data contained inside the
@@ -12,8 +11,7 @@ class TxSender {
 
   /// Builds a new [TxSender] given a [ClientChannel].
   factory TxSender.build(GrpcOrGrpcWebClientChannel channel) {
-    CC.ClientChannel cc = channel as CC.ClientChannel; 
-    return TxSender(client: tx.ServiceClient(cc));
+    return TxSender(client: tx.ServiceClient(channel));
   }
 
   /// Builds a new [TxSender] from the given [NetworkInfo].

--- a/lib/transactions/signer/tx_signer.dart
+++ b/lib/transactions/signer/tx_signer.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:alan/alan.dart';
 import 'package:alan/proto/cosmos/crypto/secp256k1/export.dart' as secp256;
 import 'package:grpc/grpc_or_grpcweb.dart';
-import 'package:grpc/src/client/channel.dart' as CC;
 import 'package:http/http.dart' as http;
 import 'package:protobuf/protobuf.dart';
 
@@ -24,7 +23,6 @@ class TxSigner {
     GrpcOrGrpcWebClientChannel clientChannel,
     http.Client httpClient,
   ) {
-    CC.ClientChannel cc = clientChannel as CC.ClientChannel;
     return TxSigner(
       authQuerier: AuthQuerier.build(clientChannel),
       nodeQuerier: NodeQuerier.build(clientChannel),

--- a/lib/transactions/signer/tx_signer.dart
+++ b/lib/transactions/signer/tx_signer.dart
@@ -2,7 +2,8 @@ import 'dart:typed_data';
 
 import 'package:alan/alan.dart';
 import 'package:alan/proto/cosmos/crypto/secp256k1/export.dart' as secp256;
-import 'package:grpc/grpc.dart' as grpc;
+import 'package:grpc/grpc_or_grpcweb.dart';
+import 'package:grpc/src/client/channel.dart' as CC;
 import 'package:http/http.dart' as http;
 import 'package:protobuf/protobuf.dart';
 
@@ -20,9 +21,10 @@ class TxSigner {
 
   /// Builds a new [TxSigner] from a given gRPC client channel and HTTP client.
   factory TxSigner.build(
-    grpc.ClientChannel clientChannel,
+    GrpcOrGrpcWebClientChannel clientChannel,
     http.Client httpClient,
   ) {
+    CC.ClientChannel cc = clientChannel as CC.ClientChannel;
     return TxSigner(
       authQuerier: AuthQuerier.build(clientChannel),
       nodeQuerier: NodeQuerier.build(clientChannel),

--- a/lib/wallet/network_info.dart
+++ b/lib/wallet/network_info.dart
@@ -28,13 +28,13 @@ class GRPCInfo extends Equatable {
   @JsonKey(name: 'host', required: true)
   final String host;
 
-  @JsonKey(name: 'webHost', required: false)
+  @JsonKey(name: 'web_host', required: false)
   final String? webHost;
 
-  @JsonKey(name: 'webPort', defaultValue: 443)
+  @JsonKey(name: 'web_port', defaultValue: 443)
   final int webPort;
 
-  @JsonKey(name: 'webTransportSecure', defaultValue: true)
+  @JsonKey(name: 'web_transport_secure', defaultValue: true)
   final bool webTransportSecure;
 
   @JsonKey(name: 'port', defaultValue: 9090)
@@ -53,19 +53,20 @@ class GRPCInfo extends Equatable {
     this.credentials = const ChannelCredentials.insecure(),
     this.webHost,
     this.webPort = 443,
-    this.webTransportSecure = true
+    this.webTransportSecure = true,
   });
 
   /// Creates a new [ClientChannel] using the optional given options.
   GrpcOrGrpcWebClientChannel getChannel() {
-    String finaleWebHost = webHost ?? host;
+    final finaleWebHost = webHost ?? host;
     return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
-      grpcHost: host.replaceFirst(RegExp('http(s)?:\/\/'), ''), 
-      grpcPort: port, 
-      grpcTransportSecure: credentials == ChannelCredentials.secure(), 
-      grpcWebHost: finaleWebHost.replaceFirst(RegExp('http(s)?:\/\/'), ''), 
-      grpcWebPort: webPort, 
-      grpcWebTransportSecure: webTransportSecure);
+      grpcHost: host.replaceFirst(RegExp('http(s)?:\/\/'), ''),
+      grpcPort: port,
+      grpcTransportSecure: credentials == ChannelCredentials.secure(),
+      grpcWebHost: finaleWebHost.replaceFirst(RegExp('http(s)?:\/\/'), ''),
+      grpcWebPort: webPort,
+      grpcWebTransportSecure: webTransportSecure,
+    );
   }
 
   factory GRPCInfo.fromJson(Map<String, dynamic> json) {
@@ -93,6 +94,9 @@ class GRPCInfo extends Equatable {
     return 'GRPCInfo {'
         'host: $host, '
         'port: $port '
+        'webHost: $webHost, '
+        'webPort: $webPort, '
+        'webTransportSecure: $webTransportSecure, '
         '}';
   }
 }

--- a/lib/wallet/network_info.dart
+++ b/lib/wallet/network_info.dart
@@ -58,11 +58,12 @@ class GRPCInfo extends Equatable {
 
   /// Creates a new [ClientChannel] using the optional given options.
   GrpcOrGrpcWebClientChannel getChannel() {
+    String finaleWebHost = webHost ?? host;
     return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
-      grpcHost: host, 
+      grpcHost: host.replaceFirst(RegExp('http(s)?:\/\/'), ''), 
       grpcPort: port, 
       grpcTransportSecure: credentials == ChannelCredentials.secure(), 
-      grpcWebHost: webHost ?? host, 
+      grpcWebHost: finaleWebHost.replaceFirst(RegExp('http(s)?:\/\/'), ''), 
       grpcWebPort: webPort, 
       grpcWebTransportSecure: webTransportSecure);
   }

--- a/lib/wallet/network_info.g.dart
+++ b/lib/wallet/network_info.g.dart
@@ -17,11 +17,17 @@ GRPCInfo _$GRPCInfoFromJson(Map<String, dynamic> json) {
     credentials: json['channel_credentials'] == null
         ? const ChannelCredentials.insecure()
         : channelOptionsFromJson(json['channel_credentials'] as String),
+    webHost: json['webHost'] as String?,
+    webPort: json['webPort'] as int? ?? 443,
+    webTransportSecure: json['webTransportSecure'] as bool? ?? true,
   );
 }
 
 Map<String, dynamic> _$GRPCInfoToJson(GRPCInfo instance) => <String, dynamic>{
       'host': instance.host,
+      'webHost': instance.webHost,
+      'webPort': instance.webPort,
+      'webTransportSecure': instance.webTransportSecure,
       'port': instance.port,
       'channel_credentials': channelCredentialsToJson(instance.credentials),
     };

--- a/test/transactions/send/tx_sender_test.mocks.dart
+++ b/test/transactions/send/tx_sender_test.mocks.dart
@@ -23,8 +23,8 @@ import 'package:mockito/mockito.dart' as _i1;
 class _FakeResponseFuture_0<R> extends _i1.Fake
     implements _i2.ResponseFuture<R> {}
 
-class _FakeClientCall_1<Q, R> extends _i1.Fake implements _i3.ClientCall<Q, R> {
-}
+class _FakeClientCall_1<Q, R> extends _i1.Fake
+    implements _i3.ClientCall<Q, R> {}
 
 class _FakeResponseStream_2<R> extends _i1.Fake
     implements _i2.ResponseStream<R> {}

--- a/test/x/auth/querier_test.mocks.dart
+++ b/test/x/auth/querier_test.mocks.dart
@@ -23,8 +23,8 @@ import 'package:mockito/mockito.dart' as _i1;
 class _FakeResponseFuture_0<R> extends _i1.Fake
     implements _i2.ResponseFuture<R> {}
 
-class _FakeClientCall_1<Q, R> extends _i1.Fake implements _i3.ClientCall<Q, R> {
-}
+class _FakeClientCall_1<Q, R> extends _i1.Fake
+    implements _i3.ClientCall<Q, R> {}
 
 class _FakeResponseStream_2<R> extends _i1.Fake
     implements _i2.ResponseStream<R> {}

--- a/test/x/node/querier_test.mocks.dart
+++ b/test/x/node/querier_test.mocks.dart
@@ -24,8 +24,8 @@ import 'package:mockito/mockito.dart' as _i1;
 class _FakeResponseFuture_0<R> extends _i1.Fake
     implements _i2.ResponseFuture<R> {}
 
-class _FakeClientCall_1<Q, R> extends _i1.Fake implements _i3.ClientCall<Q, R> {
-}
+class _FakeClientCall_1<Q, R> extends _i1.Fake
+    implements _i3.ClientCall<Q, R> {}
 
 class _FakeResponseStream_2<R> extends _i1.Fake
     implements _i2.ResponseStream<R> {}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Use `GrpcOrGrpcWebClientChannel` class from `grpc` package so also browsers will be able to communicate
with the GrpcWeb server of cosmos-sdk based blockchains.

Closes #172

## Checklist
- [ ] Targeted PR against correct branch -yup.
- [ ] [#140 ](https://github.com/alan-sdk/alan.dart/issues/140)
- [ ] manual testing by me. tests includes android and web platforms against an cosmos-sdk based blockchain grpc and grpcweb servers respectfully.
- [ ] Run `make format` - nop.
- [ ] Run `make lint` -  nop.
- [ ] no need as nothing else should be made by the developer for the default behavior.
- [ ] left it to the maintainers.
- [ ] Re-reviewed `Files changed` in the Github PR explorer and added meaningful comments - nop.
