### PR TITLE
chore: upgrade linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
         if: env.GIT_DIFF
         uses: dart-lang/setup-dart@v1.4
         with:
-          sdk: 2.17.5
+          sdk: 3.0.0
 
       - name: Get dependencies 📥
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup 🔨
         uses: dart-lang/setup-dart@v1.4
         with:
-          sdk: 2.17.5
+          sdk: 3.0.0
 
       - name: Get dependencies 📥
         run: dart pub get

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude:

--- a/example/example.dart
+++ b/example/example.dart
@@ -53,8 +53,8 @@ void main() async {
 
   // Check the result
   if (response.isSuccessful) {
-    print('Tx sent successfully. Response: ${response}');
+    print('Tx sent successfully. Response: $response');
   } else {
-    print('Tx errored: ${response}');
+    print('Tx errored: $response');
   }
 }

--- a/lib/codec/codec.dart
+++ b/lib/codec/codec.dart
@@ -11,9 +11,7 @@ class AccountImpl {
   String typeUrl;
   AccountDeserializer deserializer;
 
-  AccountImpl(String typeUrl, AccountDeserializer deserializer)
-      : typeUrl = typeUrl,
-        deserializer = deserializer;
+  AccountImpl(this.typeUrl, this.deserializer);
 }
 
 /// Represents the codec that is used to serialize [StdMsg] instances

--- a/lib/transactions/builder/tx_builder.dart
+++ b/lib/transactions/builder/tx_builder.dart
@@ -39,7 +39,7 @@ class TxBuilder {
 
     for (var index = 0; index < signatures.length; index++) {
       final signature = signatures[index];
-      if (!(signature.data is SingleSignatureData)) {
+      if (signature.data is! SingleSignatureData) {
         throw Exception('Signature data not supported: ${signature.data}');
       }
 

--- a/lib/transactions/config/default.dart
+++ b/lib/transactions/config/default.dart
@@ -10,7 +10,7 @@ class DefaultTxConfig extends TxConfig {
 
   @override
   TxEncoder txEncoder() {
-    return DefaultEncoder();
+    return defaultEncoder();
   }
 
   @override

--- a/lib/transactions/encoder/default.dart
+++ b/lib/transactions/encoder/default.dart
@@ -1,7 +1,7 @@
 import 'package:alan/alan.dart';
 
 /// Returns a default protobuf TxEncoder.
-TxEncoder DefaultEncoder() {
+TxEncoder defaultEncoder() {
   return (Tx tx) {
     // Check the body
     if (!tx.hasBody()) {

--- a/lib/types/ext_bigint.dart
+++ b/lib/types/ext_bigint.dart
@@ -6,13 +6,13 @@ extension BigIntExtension on BigInt {
   /// the big-endian encoding.
   Uint8List toUin8List() {
     // Not handling negative numbers. Decide how you want to do that.
-    final _byteMask = BigInt.from(0xff);
+    final byteMask = BigInt.from(0xff);
     var number = this;
     final size = (number.bitLength + 7) >> 3;
     final result = Uint8List(size);
 
     for (var i = 0; i < size; i++) {
-      result[size - i - 1] = (number & _byteMask).toInt();
+      result[size - i - 1] = (number & byteMask).toInt();
       number = number >> 8;
     }
     return result;

--- a/lib/utils/bip_32.dart
+++ b/lib/utils/bip_32.dart
@@ -5,13 +5,13 @@ import 'package:convert/convert.dart';
 import 'package:pointycastle/export.dart';
 
 class Bip32 {
-  static const _bitcoinNetworkType = _NetworkType(
+  static const _bitcoinNetworkType = NetworkType(
     wif: 0x80,
-    bip32: _Bip32Type(public: 0x0488b21e, private: 0x0488ade4),
+    bip32: Bip32Type(public: 0x0488b21e, private: 0x0488ade4),
   );
-  static const _UINT32_MAX = 4294967295; // 2^32 - 1
-  static const _UINT31_MAX = 2147483647; // 2^31 - 1
-  static const _HIGHEST_BIT = 0x80000000;
+  static const _uint32Max = 4294967295; // 2^32 - 1
+  static const _uint31Max = 2147483647; // 2^31 - 1
+  static const _highestBit = 0x80000000;
   static final _secp256k1 = ECCurve_secp256k1();
 
   /// Internal re-implementation of https://pub.dev/packages/bip32
@@ -29,7 +29,7 @@ class Bip32 {
   final Uint8List? privateKey;
   Uint8List? _publicKey;
   final Uint8List chainCode;
-  final _NetworkType network;
+  final NetworkType network;
   int depth;
   int index;
   int parentFingerprint;
@@ -141,11 +141,11 @@ class Bip32 {
   Bip32 derive(int index, {Bip32EccCurve? ecc}) {
     ecc ??= Bip32EccCurve();
 
-    if (index > _UINT32_MAX || index < 0) {
+    if (index > _uint32Max || index < 0) {
       throw ArgumentError('Expected UInt32');
     }
 
-    final isHardened = index >= _HIGHEST_BIT;
+    final isHardened = index >= _highestBit;
     final data = Uint8List(37);
 
     if (isHardened) {
@@ -198,11 +198,11 @@ class Bip32 {
   }
 
   Bip32 deriveHardened(int index) {
-    if (index > _UINT31_MAX || index < 0) {
+    if (index > _uint31Max || index < 0) {
       throw ArgumentError('Expected UInt31');
     }
 
-    return derive(index + _HIGHEST_BIT);
+    return derive(index + _highestBit);
   }
 
   bool isNeutered() {
@@ -210,27 +210,27 @@ class Bip32 {
   }
 }
 
-class _NetworkType {
-  const _NetworkType({required this.wif, required this.bip32});
+class NetworkType {
+  const NetworkType({required this.wif, required this.bip32});
 
   final int wif;
-  final _Bip32Type bip32;
+  final Bip32Type bip32;
 }
 
-class _Bip32Type {
-  const _Bip32Type({required this.public, required this.private});
+class Bip32Type {
+  const Bip32Type({required this.public, required this.private});
 
   final int public;
   final int private;
 }
 
 class Bip32EccCurve {
-  static final _ZERO32 = Uint8List.fromList(List.generate(32, (index) => 0));
-  static final _EC_GROUP_ORDER = Uint8List.fromList(
+  static final _zero32 = Uint8List.fromList(List.generate(32, (index) => 0));
+  static final _ecGroupOrder = Uint8List.fromList(
     hex.decode(
         'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141'),
   );
-  final _EC_P = Uint8List.fromList(hex.decode(
+  final _ecP = Uint8List.fromList(hex.decode(
       'fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f'));
 
   bool isPrivate(Uint8List x) {
@@ -238,8 +238,8 @@ class Bip32EccCurve {
       return false;
     }
 
-    return _compare(x, _ZERO32) > 0 && // > 0
-        _compare(x, _EC_GROUP_ORDER) < 0; // < G
+    return _compare(x, _zero32) > 0 && // > 0
+        _compare(x, _ecGroupOrder) < 0; // < G
   }
 
   bool isScalar(Uint8List x) {
@@ -297,7 +297,7 @@ class Bip32EccCurve {
 
     final pp = Bip32._secp256k1.curve.decodePoint(p);
 
-    if (_compare(tweak, _ZERO32) == 0) {
+    if (_compare(tweak, _zero32) == 0) {
       return pp!.getEncoded(true);
     }
 
@@ -320,11 +320,11 @@ class Bip32EccCurve {
     final t = p[0];
     final x = p.sublist(1, 33);
 
-    if (_compare(x, _ZERO32) == 0) {
+    if (_compare(x, _zero32) == 0) {
       return false;
     }
 
-    if (_compare(x, _EC_P) == 1) {
+    if (_compare(x, _ecP) == 1) {
       return false;
     }
 
@@ -339,11 +339,11 @@ class Bip32EccCurve {
     }
 
     final y = p.sublist(33);
-    if (_compare(y, _ZERO32) == 0) {
+    if (_compare(y, _zero32) == 0) {
       return false;
     }
 
-    if (_compare(y, _EC_P) == 1) {
+    if (_compare(y, _ecP) == 1) {
       return false;
     }
 
@@ -359,7 +359,7 @@ class Bip32EccCurve {
       return false;
     }
 
-    return _compare(x, _EC_GROUP_ORDER) < 0; // < G
+    return _compare(x, _ecGroupOrder) < 0; // < G
   }
 
   Uint8List pointFromScalar(Uint8List d) {

--- a/lib/utils/bip_39.dart
+++ b/lib/utils/bip_39.dart
@@ -5,21 +5,21 @@ import 'package:bip39/bip39.dart' as bip39;
 /// Wrapper around the Bip-39 library making it easier to deal with
 /// mnemonic phrases.
 class Bip39 {
-  static const _SEPARATOR = ' ';
+  static const _separator = ' ';
 
   /// Returns [true] if the provided mnemonic is valid, or [false] otherwise.
   static bool validateMnemonic(List<String> mnemonic) {
-    return bip39.validateMnemonic(mnemonic.join(_SEPARATOR));
+    return bip39.validateMnemonic(mnemonic.join(_separator));
   }
 
   /// Returns a seed from the provided mnemonic that can be used to generate
   /// a new wallet.
   static Uint8List mnemonicToSeed(List<String> mnemonic) {
-    return bip39.mnemonicToSeed(mnemonic.join(_SEPARATOR));
+    return bip39.mnemonicToSeed(mnemonic.join(_separator));
   }
 
   /// Returns a randomly generated seed phrase.
   static List<String> generateMnemonic({int strength = 128}) {
-    return bip39.generateMnemonic(strength: strength).split(_SEPARATOR);
+    return bip39.generateMnemonic(strength: strength).split(_separator);
   }
 }

--- a/lib/wallet/network_info.dart
+++ b/lib/wallet/network_info.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
-import 'package:grpc/grpc.dart';
+import 'package:grpc/src/client/options.dart';
 import 'package:grpc/grpc_or_grpcweb.dart';
+import 'package:grpc/src/client/transport/http2_credentials.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'network_info.g.dart';
@@ -28,15 +29,6 @@ class GRPCInfo extends Equatable {
   @JsonKey(name: 'host', required: true)
   final String host;
 
-  @JsonKey(name: 'web_host', required: false)
-  final String? webHost;
-
-  @JsonKey(name: 'web_port', defaultValue: 443)
-  final int webPort;
-
-  @JsonKey(name: 'web_transport_secure', defaultValue: true)
-  final bool webTransportSecure;
-
   @JsonKey(name: 'port', defaultValue: 9090)
   final int port;
 
@@ -51,21 +43,14 @@ class GRPCInfo extends Equatable {
     required this.host,
     this.port = 9090,
     this.credentials = const ChannelCredentials.insecure(),
-    this.webHost,
-    this.webPort = 443,
-    this.webTransportSecure = true,
   });
 
   /// Creates a new [ClientChannel] using the optional given options.
   GrpcOrGrpcWebClientChannel getChannel() {
-    final finaleWebHost = webHost ?? host;
-    return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
-      grpcHost: host.replaceFirst(RegExp('http(s)?:\/\/'), ''),
-      grpcPort: port,
-      grpcTransportSecure: credentials == ChannelCredentials.secure(),
-      grpcWebHost: finaleWebHost.replaceFirst(RegExp('http(s)?:\/\/'), ''),
-      grpcWebPort: webPort,
-      grpcWebTransportSecure: webTransportSecure,
+    return GrpcOrGrpcWebClientChannel.grpc(
+      host.replaceFirst(RegExp('http(s)?:\/\/'), ''),
+      port: port,
+      options: ChannelOptions(credentials: credentials),
     );
   }
 
@@ -83,9 +68,6 @@ class GRPCInfo extends Equatable {
       host,
       port,
       credentials.isSecure,
-      webHost,
-      webPort,
-      webTransportSecure
     ];
   }
 
@@ -94,9 +76,6 @@ class GRPCInfo extends Equatable {
     return 'GRPCInfo {'
         'host: $host, '
         'port: $port '
-        'webHost: $webHost, '
-        'webPort: $webPort, '
-        'webTransportSecure: $webTransportSecure, '
         '}';
   }
 }

--- a/lib/wallet/network_info.dart
+++ b/lib/wallet/network_info.dart
@@ -1,8 +1,7 @@
 // ignore_for_file: implementation_imports
 import 'package:equatable/equatable.dart';
-import 'package:grpc/src/client/options.dart';
+import 'package:grpc/grpc.dart';
 import 'package:grpc/grpc_or_grpcweb.dart';
-import 'package:grpc/src/client/transport/http2_credentials.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 part 'network_info.g.dart';
@@ -30,6 +29,15 @@ class GRPCInfo extends Equatable {
   @JsonKey(name: 'host', required: true)
   final String host;
 
+  @JsonKey(name: 'web_host', required: false)
+  final String? webHost;
+
+  @JsonKey(name: 'web_port', defaultValue: 443)
+  final int webPort;
+
+  @JsonKey(name: 'web_transport_secure', defaultValue: true)
+  final bool webTransportSecure;
+
   @JsonKey(name: 'port', defaultValue: 9090)
   final int port;
 
@@ -44,14 +52,21 @@ class GRPCInfo extends Equatable {
     required this.host,
     this.port = 9090,
     this.credentials = const ChannelCredentials.insecure(),
+    this.webHost,
+    this.webPort = 443,
+    this.webTransportSecure = true,
   });
 
   /// Creates a new [ClientChannel] using the optional given options.
   GrpcOrGrpcWebClientChannel getChannel() {
-    return GrpcOrGrpcWebClientChannel.grpc(
-      host.replaceFirst(RegExp('http(s)?://'), ''),
-      port: port,
-      options: ChannelOptions(credentials: credentials),
+    final finaleWebHost = webHost ?? host;
+    return GrpcOrGrpcWebClientChannel.toSeparateEndpoints(
+      grpcHost: host.replaceFirst(RegExp('http(s)?://'), ''),
+      grpcPort: port,
+      grpcTransportSecure: credentials == ChannelCredentials.secure(),
+      grpcWebHost: finaleWebHost.replaceFirst(RegExp('http(s)?://'), ''),
+      grpcWebPort: webPort,
+      grpcWebTransportSecure: webTransportSecure,
     );
   }
 
@@ -69,6 +84,9 @@ class GRPCInfo extends Equatable {
       host,
       port,
       credentials.isSecure,
+      webHost,
+      webPort,
+      webTransportSecure
     ];
   }
 
@@ -77,6 +95,9 @@ class GRPCInfo extends Equatable {
     return 'GRPCInfo {'
         'host: $host, '
         'port: $port '
+        'webHost: $webHost, '
+        'webPort: $webPort, '
+        'webTransportSecure: $webTransportSecure, '
         '}';
   }
 }

--- a/lib/wallet/network_info.dart
+++ b/lib/wallet/network_info.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: implementation_imports
 import 'package:equatable/equatable.dart';
 import 'package:grpc/src/client/options.dart';
 import 'package:grpc/grpc_or_grpcweb.dart';
@@ -6,18 +7,18 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'network_info.g.dart';
 
-const _CHANNEL_CREDENTIAL_SECURE = 'secure';
-const _CHANNEL_CREDENTIAL_INSECURE = 'insecure';
+const _channelCredentialSecure = 'secure';
+const _channelCredentialInsecure = 'insecure';
 
 Object channelCredentialsToJson(ChannelCredentials credentials) {
   if (credentials.isSecure) {
-    return _CHANNEL_CREDENTIAL_SECURE;
+    return _channelCredentialSecure;
   }
-  return _CHANNEL_CREDENTIAL_INSECURE;
+  return _channelCredentialInsecure;
 }
 
 ChannelCredentials channelOptionsFromJson(String value) {
-  if (value == _CHANNEL_CREDENTIAL_INSECURE) {
+  if (value == _channelCredentialInsecure) {
     return ChannelCredentials.insecure();
   }
   return ChannelCredentials.secure();
@@ -48,7 +49,7 @@ class GRPCInfo extends Equatable {
   /// Creates a new [ClientChannel] using the optional given options.
   GrpcOrGrpcWebClientChannel getChannel() {
     return GrpcOrGrpcWebClientChannel.grpc(
-      host.replaceFirst(RegExp('http(s)?:\/\/'), ''),
+      host.replaceFirst(RegExp('http(s)?://'), ''),
       port: port,
       options: ChannelOptions(credentials: credentials),
     );
@@ -105,7 +106,7 @@ class LCDInfo extends Equatable {
   /// Returns the full URL of the LCD endpoint
   String get fullUrl {
     var hostWithProtocol = host;
-    if (!hostWithProtocol.startsWith(RegExp('http(s)?:\/\/'))) {
+    if (!hostWithProtocol.startsWith(RegExp('http(s)?://'))) {
       hostWithProtocol = 'http://$hostWithProtocol';
     }
     return '$hostWithProtocol:$port';

--- a/lib/wallet/wallet.dart
+++ b/lib/wallet/wallet.dart
@@ -13,7 +13,7 @@ import 'package:pointycastle/export.dart';
 /// The associated [networkInfo] will be used when computing the [bech32Address]
 /// associated with the wallet.
 class Wallet extends Equatable {
-  static const DERIVATION_PATH = "m/44'/118'/0'/0/0";
+  static const derivationPath = "m/44'/118'/0'/0/0";
 
   final Uint8List address;
   final Uint8List privateKey;
@@ -33,7 +33,7 @@ class Wallet extends Equatable {
   factory Wallet.derive(
     List<String> mnemonic,
     NetworkInfo networkInfo, {
-    String derivationPath = DERIVATION_PATH,
+    String derivationPath = derivationPath,
   }) {
     // Validate the mnemonic
     if (!Bip39.validateMnemonic(mnemonic)) {
@@ -75,7 +75,7 @@ class Wallet extends Equatable {
   /// and the optional [derivationPath].
   factory Wallet.random(
     NetworkInfo networkInfo, {
-    String derivationPath = DERIVATION_PATH,
+    String derivationPath = derivationPath,
   }) {
     return Wallet.derive(
       Bip39.generateMnemonic(strength: 256),

--- a/lib/x/auth/account.dart
+++ b/lib/x/auth/account.dart
@@ -35,7 +35,7 @@ class BaseAccount extends AccountI {
     return account.sequence;
   }
 
-  BaseAccount(auth.BaseAccount account) : account = account;
+  BaseAccount(this.account);
 
   static BaseAccount fromAny(Any any) {
     final account = auth.BaseAccount.fromBuffer(any.value);
@@ -66,7 +66,7 @@ class ModuleAccount implements AccountI {
     return account.baseAccount.sequence;
   }
 
-  ModuleAccount(auth.ModuleAccount account) : account = account;
+  ModuleAccount(this.account);
 
   static ModuleAccount fromAny(Any any) {
     final account = auth.ModuleAccount.fromBuffer(any.value);

--- a/lib/x/vesting/vesting_account.dart
+++ b/lib/x/vesting/vesting_account.dart
@@ -25,7 +25,7 @@ class BaseVestingAccount implements AccountI {
     return account.baseAccount.sequence;
   }
 
-  BaseVestingAccount(vesting.BaseVestingAccount account) : account = account;
+  BaseVestingAccount(this.account);
 
   static BaseVestingAccount fromAny(Any any) {
     final account = vesting.BaseVestingAccount.fromBuffer(any.value);
@@ -56,8 +56,7 @@ class DelayedVestingAccount implements AccountI {
     return account.baseVestingAccount.baseAccount.sequence;
   }
 
-  DelayedVestingAccount(vesting.DelayedVestingAccount account)
-      : account = account;
+  DelayedVestingAccount(this.account);
 
   static DelayedVestingAccount fromAny(Any any) {
     final account = vesting.DelayedVestingAccount.fromBuffer(any.value);
@@ -88,8 +87,7 @@ class ContinuousVestingAccount implements AccountI {
     return account.baseVestingAccount.baseAccount.sequence;
   }
 
-  ContinuousVestingAccount(vesting.ContinuousVestingAccount account)
-      : account = account;
+  ContinuousVestingAccount(this.account);
 
   static ContinuousVestingAccount fromAny(Any any) {
     final account = vesting.ContinuousVestingAccount.fromBuffer(any.value);
@@ -120,8 +118,7 @@ class PeriodicVestingAccount implements AccountI {
     return account.baseVestingAccount.baseAccount.sequence;
   }
 
-  PeriodicVestingAccount(vesting.PeriodicVestingAccount account)
-      : account = account;
+  PeriodicVestingAccount(this.account);
 
   static PeriodicVestingAccount fromAny(Any any) {
     final account = vesting.PeriodicVestingAccount.fromBuffer(any.value);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,567 +5,648 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "4897882604d919befd350648c7f91926a9d5de99e67b455bf0917cc2362f4bb8"
+      url: "https://pub.dev"
     source: hosted
     version: "59.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "690e335554a8385bc9d787117d9eb52c0c03ee207a607e593de3c9d71b1cfe80"
+      url: "https://pub.dev"
     source: hosted
     version: "5.11.1"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: a92e39b291073bb840a72cf43d96d2a63c74e9a485d227833e8ea0054d16ad16
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "37a4264b0b7fb930e94c0c47558f3b6c4f4e9cb7e655a3ea373131d79b2dc0cc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   asn1lib:
     dependency: "direct main"
     description:
       name: asn1lib
-      url: "https://pub.dartlang.org"
+      sha256: c8e7571a1e9177db4c9b8de1b8f0e462dda18f397eed40b3787d90171d6251e7
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "271b8899fc99f9df4f4ed419fa14e2fff392c7b2c162fbb87b222e2e963ddc73"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   bech32:
     dependency: "direct main"
     description:
       name: bech32
-      url: "https://pub.dartlang.org"
+      sha256: c36ff22d905b5864cafa7a3cf5e65dd2ca26cff30db1d6a9bd1bbfa2a231e58f
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
   bip39:
     dependency: "direct main"
     description:
       name: bip39
-      url: "https://pub.dartlang.org"
+      sha256: de1ee27ebe7d96b84bb3a04a4132a0a3007dcdd5ad27dd14aa87a29d97c45edc
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "29a03af98de60b4eb9136acd56608a54e989f6da238a80af739415b05589d6df"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: "5b7355c14258f5e7df24bad1566f7b991de3e54aeacfb94e1a65e5233d9739c1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "9aae031a54ab0beebc30a888c93e900d15ae2fd8883d031dbfbd5ebdb57f5a4c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.10"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: e3b4e8eab6b9bdb57059e9290a7ddc0ec61b617ac862fe4d973bf6eb90475b85
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: f4d6244cc071ba842c296cb1c4ee1b31596b9f924300647ac7a1445493471a3f
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: f5a2a975d3da1ca46579d2f173bea1c766f0044cff40889c8df8009bf6ea0d0c
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "8f4772ec1e72822da7213627a0db16029085a8d709a9032e77b9a049209b6cb2"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: "8e36feea6de5ea69f2199f29cf42a450a855738c498b57c0b980e2d3cca9c362"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "02ce3596b459c666530f045ad6f96209474e8fee6e4855940a3cee65fb872ec5"
+      url: "https://pub.dev"
     source: hosted
     version: "4.3.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "6d4193120997ecfd09acf0e313f13dc122b119e5eca87ef57a7d065ec9183762"
+      url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
   convert:
     dependency: "direct main"
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2890d8a09829de2cc3ead1407960549e4eb3c4e48c8fb837bfa5c68398496489"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "8aff82f9b26fd868992e5430335a9d773bfef01e1d852d7ba71bf4c5d9349351"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
   equatable:
     dependency: "direct main"
     description:
       name: equatable
-      url: "https://pub.dartlang.org"
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "9fd2163d866769f60f4df8ac1dc59f52498d810c356fe78022e383dd3c57c0e1"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
   fixnum:
     dependency: "direct main"
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "4f4a162323c86ffc1245765cfe138872b8f069deb42f7dbb36115fa27f31469b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: dda85ce2aefce16f7e75586acbcb1e8320bf176f69fd94082e31945d6de67f3e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   googleapis_auth:
     dependency: transitive
     description:
       name: googleapis_auth
-      url: "https://pub.dartlang.org"
+      sha256: f63e6474a33e3e1be273dc24a7ba36abcbb2d71c2d1153c4c4de8ecdf7dbb815
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: ae0b3d956ff324c6f8671f08dcb2dbd71c99cdbf2aa3ca63a14190c47aa6679c
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   grpc:
     dependency: "direct main"
     description:
       name: grpc
-      url: "https://pub.dartlang.org"
+      sha256: "3e8e04c6277059b66d67951143842097e52bbf3f2c6fca2e67d3607b48d5c3ab"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   hex:
     dependency: "direct main"
     description:
       name: hex
-      url: "https://pub.dartlang.org"
+      sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.6"
   http2:
     dependency: transitive
     description:
       name: http2
-      url: "https://pub.dartlang.org"
+      sha256: feb9fbe4790be90fef454eb930368c40ae56df598b3e9b9c10cc216d68f75720
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: ac10cae1b9a06fb638a92a72b00570bac856f524f7ee0d9a13eaed4960c7fd43
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "15a5436d2a02dc60e6dc2fb5d7dfaac08b7b137cff3d4bf3158d38ecab656b69"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: "3520fa844009431b5d4491a5a778603520cdc399ab3406332dcc50f93547258c"
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
   json_serializable:
     dependency: "direct main"
     description:
       name: json_serializable
-      url: "https://pub.dartlang.org"
+      sha256: "276b80dd382d29e253b20db49911c590caa1c62737446fb3ed9facc12da54202"
+      url: "https://pub.dev"
     source: hosted
     version: "6.6.2"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "0520a4826042a8a5d09ddd4755623a50d37ee536d79a70452aff8c8ad7bb6c27"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "2e2c34e631f93410daa3ee3410250eadc77ac6befc02a040eda8a123f34e6f5a"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.15"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: a7a98ea7f366e2cc9d2b20873815aebec5e2bc124fe0da9d3f7f59b0625ea180
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   mock_web_server:
     dependency: "direct dev"
     description:
       name: mock_web_server
-      url: "https://pub.dartlang.org"
+      sha256: d6ec0d2a644c2ff5ef86da4360743e33f65c0fcf780555b913107502ac51a98e
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0-nullsafety.1"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      url: "https://pub.dartlang.org"
+      sha256: "2a8a17b82b1bde04d514e75d90d634a0ac23f6cb4991f6098009dd56836aeafe"
+      url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: c133f761a6a790d0b000efa4f74eae9700bb6e9e9f5e996f0e8d6fe92703ced6
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "20e7154d701fedaeb219dad732815ecb66677667871127998a9a6581c2aba4ba"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "2ad4cddff7f5cc0e2d13069f2a3f7a73ca18f66abd6f5ecf215219cdb3638edb"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
-      url: "https://pub.dartlang.org"
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
   pointycastle:
     dependency: "direct main"
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
     source: hosted
     version: "3.7.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "05955e3de2683e1746222efd14b775df7131139e07695dc8e24650f6b4204504"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   protobuf:
     dependency: "direct main"
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "59ed538734419e81f7fc18c98249ae72c3c7188bdd9dceff2840585227f79843"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "358c5ce09744e0e08b3f5f38c53d7d26a8219dd641718f8500f49cfa56240358"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c2f658d28ec86857657dec3579e2db4dc5a6c477b6aecde870e77f0682258901
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: e0b44ebddec91e70a713e13adf93c1b2100821303b86a18e1ef1d082bd8bd9b8
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: "8584c0aa0f5756a61519b1a2fc2cd22ddbc518e9396bd33ebf06b9836bb23d13"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: fd84910bf7d58db109082edf7326b75322b8f186162028482f53dc892f00332d
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: "00f8b6b586f724a8c769c96f1d517511a41661c0aede644544d8d86a1ab11142"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.5"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      url: "https://pub.dartlang.org"
+      sha256: "522d9b05c40ec14f479ce4428337d106c0465fedab42f514582c198460a784fe"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: d5f89a9e52b36240a80282b3dc0667dd36e53459717bb17b8fb102d30496606a
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: ed464977cb26a1f41537e177e190c67223dbd9f4f683489b6ab2e5d211ec564e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "9ffb8dbda445ba2922522423e7c7288967de89129205ce2dadf856abfd2b72ae"
+      url: "https://pub.dev"
     source: hosted
     version: "1.24.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ceeddf59d613e862e77f4b506cfc2945ac9637ce0b4c00f4f4c1ac639f3e9731
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "2b38b8ecfa37f8d375b4aa2a106a86ade536b577411530c2ea68c83abb1f004b"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: c386d07d7f5efc613479a7c4d9d64b03710b03cfaa7e8ad5f2bfb295a1f0dfad
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: "422eda09e2a50eb27fe9eca2c897d624cea7fa432a8442e1ea1a10d50a4321ab"
+      url: "https://pub.dev"
     source: hosted
     version: "6.2.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "68173f2fa67d241323a4123be7ed4e43424c54befa5505d71c8ad4b7baf8f71d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "500e6014efebd305a30ebf1c6006d13faa82dcd85c7a2a7793679a64ed69ec48"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "5adb6ab8ed14e22bb907aae7338f0c206ea21e7a27004e97664b16c120306f00"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3cee79b1715110341012d27756d9bae38e650588acd38d3f3c610822e1337ace"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
 sdks:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,39 +5,39 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "4897882604d919befd350648c7f91926a9d5de99e67b455bf0917cc2362f4bb8"
+      sha256: "405666cd3cf0ee0a48d21ec67e65406aad2c726d9fa58840d3375e7bdcd32a07"
       url: "https://pub.dev"
     source: hosted
-    version: "59.0.0"
+    version: "60.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: "690e335554a8385bc9d787117d9eb52c0c03ee207a607e593de3c9d71b1cfe80"
+      sha256: "1952250bd005bacb895a01bf1b4dc00e3ba1c526cf47dca54dfe24979c65f5b3"
       url: "https://pub.dev"
     source: hosted
-    version: "5.11.1"
+    version: "5.12.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      sha256: a92e39b291073bb840a72cf43d96d2a63c74e9a485d227833e8ea0054d16ad16
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.3.7"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "37a4264b0b7fb930e94c0c47558f3b6c4f4e9cb7e655a3ea373131d79b2dc0cc"
+      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.4.1"
   asn1lib:
     dependency: "direct main"
     description:
       name: asn1lib
-      sha256: c8e7571a1e9177db4c9b8de1b8f0e462dda18f397eed40b3787d90171d6251e7
+      sha256: ab96a1cb3beeccf8145c52e449233fe68364c9641623acd3adad66f8184f1039
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
@@ -45,7 +45,7 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "271b8899fc99f9df4f4ed419fa14e2fff392c7b2c162fbb87b222e2e963ddc73"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
@@ -53,7 +53,7 @@ packages:
     dependency: "direct main"
     description:
       name: bech32
-      sha256: c36ff22d905b5864cafa7a3cf5e65dd2ca26cff30db1d6a9bd1bbfa2a231e58f
+      sha256: "156cbace936f7720c79a79d16a03efad343b1ef17106716e04b8b8e39f99f7f7"
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
@@ -69,111 +69,103 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "29a03af98de60b4eb9136acd56608a54e989f6da238a80af739415b05589d6df"
+      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "5b7355c14258f5e7df24bad1566f7b991de3e54aeacfb94e1a65e5233d9739c1"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "9aae031a54ab0beebc30a888c93e900d15ae2fd8883d031dbfbd5ebdb57f5a4c"
+      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10"
+    version: "2.2.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: e3b4e8eab6b9bdb57059e9290a7ddc0ec61b617ac862fe4d973bf6eb90475b85
+      sha256: "87e06c939450b9b94e3e1bb2d46e0e9780adbff5500d3969f2ba2de6bbb860cb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f4d6244cc071ba842c296cb1c4ee1b31596b9f924300647ac7a1445493471a3f
+      sha256: "30859c90e9ddaccc484f56303931f477b1f1ba2bab74aa32ed5d6ce15870f8cf"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.8"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      sha256: f5a2a975d3da1ca46579d2f173bea1c766f0044cff40889c8df8009bf6ea0d0c
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      sha256: "8f4772ec1e72822da7213627a0db16029085a8d709a9032e77b9a049209b6cb2"
+      sha256: "2f17434bd5d52a26762043d6b43bb53b3acd029b4d9071a329f46d67ef297e6d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: "8e36feea6de5ea69f2199f29cf42a450a855738c498b57c0b980e2d3cca9c362"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
+    version: "8.5.0"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "02ce3596b459c666530f045ad6f96209474e8fee6e4855940a3cee65fb872ec5"
+      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "6d4193120997ecfd09acf0e313f13dc122b119e5eca87ef57a7d065ec9183762"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   convert:
     dependency: "direct main"
     description:
       name: convert
-      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
@@ -181,26 +173,26 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2890d8a09829de2cc3ead1407960549e4eb3c4e48c8fb837bfa5c68398496489"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8aff82f9b26fd868992e5430335a9d773bfef01e1d852d7ba71bf4c5d9349351"
+      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.3.1"
   equatable:
     dependency: "direct main"
     description:
@@ -213,15 +205,15 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "9fd2163d866769f60f4df8ac1dc59f52498d810c356fe78022e383dd3c57c0e1"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.4"
   fixnum:
     dependency: "direct main"
     description:
       name: fixnum
-      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
@@ -229,7 +221,7 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "4f4a162323c86ffc1245765cfe138872b8f069deb42f7dbb36115fa27f31469b"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
@@ -237,31 +229,31 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: dda85ce2aefce16f7e75586acbcb1e8320bf176f69fd94082e31945d6de67f3e
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   googleapis_auth:
     dependency: transitive
     description:
       name: googleapis_auth
-      sha256: f63e6474a33e3e1be273dc24a7ba36abcbb2d71c2d1153c4c4de8ecdf7dbb815
+      sha256: f59be210ede1e22718962e4ef48a08ae783eb67fe19b0f4c16b204e20df0869c
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.4.0"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      sha256: ae0b3d956ff324c6f8671f08dcb2dbd71c99cdbf2aa3ca63a14190c47aa6679c
+      sha256: "772db3d53d23361d4ffcf5a9bb091cf3ee9b22f2be52cd107cd7a2683a89ba0e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.0"
   grpc:
     dependency: "direct main"
     description:
       name: grpc
-      sha256: "3e8e04c6277059b66d67951143842097e52bbf3f2c6fca2e67d3607b48d5c3ab"
+      sha256: a73c16e4f6a4a819be892bb2c73cc1d0b00e36095f69b0738cc91a733e3d27ba
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
@@ -277,7 +269,7 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
     version: "0.13.6"
@@ -285,47 +277,47 @@ packages:
     dependency: transitive
     description:
       name: http2
-      sha256: feb9fbe4790be90fef454eb930368c40ae56df598b3e9b9c10cc216d68f75720
+      sha256: "58805ebc6513eed3b98ee0a455a8357e61d187bf2e0fdc1e53120770f78de258"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: ac10cae1b9a06fb638a92a72b00570bac856f524f7ee0d9a13eaed4960c7fd43
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "15a5436d2a02dc60e6dc2fb5d7dfaac08b7b137cff3d4bf3158d38ecab656b69"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "3520fa844009431b5d4491a5a778603520cdc399ab3406332dcc50f93547258c"
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
@@ -333,23 +325,31 @@ packages:
     dependency: "direct main"
     description:
       name: json_serializable
-      sha256: "276b80dd382d29e253b20db49911c590caa1c62737446fb3ed9facc12da54202"
+      sha256: "43793352f90efa5d8b251893a63d767b2f7c833120e3cc02adad55eefec04dc7"
       url: "https://pub.dev"
     source: hosted
     version: "6.6.2"
+  lints:
+    dependency: "direct dev"
+    description:
+      name: lints
+      sha256: "6b0206b0bf4f04961fc5438198ccb3a885685cd67d4d4a32cc20ad7f8adbe015"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "0520a4826042a8a5d09ddd4755623a50d37ee536d79a70452aff8c8ad7bb6c27"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "2e2c34e631f93410daa3ee3410250eadc77ac6befc02a040eda8a123f34e6f5a"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
     version: "0.12.15"
@@ -357,7 +357,7 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
@@ -365,10 +365,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: a7a98ea7f366e2cc9d2b20873815aebec5e2bc124fe0da9d3f7f59b0625ea180
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.4"
   mock_web_server:
     dependency: "direct dev"
     description:
@@ -381,7 +381,7 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "2a8a17b82b1bde04d514e75d90d634a0ac23f6cb4991f6098009dd56836aeafe"
+      sha256: dd61809f04da1838a680926de50a9e87385c1de91c6579629c3d1723946e8059
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
@@ -389,39 +389,31 @@ packages:
     dependency: transitive
     description:
       name: node_preamble
-      sha256: c133f761a6a790d0b000efa4f74eae9700bb6e9e9f5e996f0e8d6fe92703ced6
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "20e7154d701fedaeb219dad732815ecb66677667871127998a9a6581c2aba4ba"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "2ad4cddff7f5cc0e2d13069f2a3f7a73ca18f66abd6f5ecf215219cdb3638edb"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
-  pedantic:
-    dependency: "direct dev"
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
+    version: "1.8.3"
   pointycastle:
     dependency: "direct main"
     description:
       name: pointycastle
-      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
       url: "https://pub.dev"
     source: hosted
     version: "3.7.3"
@@ -429,10 +421,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "05955e3de2683e1746222efd14b775df7131139e07695dc8e24650f6b4204504"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   protobuf:
     dependency: "direct main"
     description:
@@ -445,63 +437,63 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "59ed538734419e81f7fc18c98249ae72c3c7188bdd9dceff2840585227f79843"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.4"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "358c5ce09744e0e08b3f5f38c53d7d26a8219dd641718f8500f49cfa56240358"
+      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c2f658d28ec86857657dec3579e2db4dc5a6c477b6aecde870e77f0682258901
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      sha256: e0b44ebddec91e70a713e13adf93c1b2100821303b86a18e1ef1d082bd8bd9b8
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: "8584c0aa0f5756a61519b1a2fc2cd22ddbc518e9396bd33ebf06b9836bb23d13"
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: fd84910bf7d58db109082edf7326b75322b8f186162028482f53dc892f00332d
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.4"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "00f8b6b586f724a8c769c96f1d517511a41661c0aede644544d8d86a1ab11142"
+      sha256: "378a173055cd1fcd2a36e94bf254786d6812688b5f53b6038a2fd180a5a5e210"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.5"
+    version: "1.3.1"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "522d9b05c40ec14f479ce4428337d106c0465fedab42f514582c198460a784fe"
+      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
@@ -509,71 +501,71 @@ packages:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: d5f89a9e52b36240a80282b3dc0667dd36e53459717bb17b8fb102d30496606a
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: ed464977cb26a1f41537e177e190c67223dbd9f4f683489b6ab2e5d211ec564e
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "9ffb8dbda445ba2922522423e7c7288967de89129205ce2dadf856abfd2b72ae"
+      sha256: "4f92f103ef63b1bbac6f4bd1930624fca81b2574464482512c4f0896319be575"
       url: "https://pub.dev"
     source: hosted
     version: "1.24.2"
@@ -581,7 +573,7 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ceeddf59d613e862e77f4b506cfc2945ac9637ce0b4c00f4f4c1ac639f3e9731
+      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
       url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
@@ -589,7 +581,7 @@ packages:
     dependency: transitive
     description:
       name: test_core
-      sha256: "2b38b8ecfa37f8d375b4aa2a106a86ade536b577411530c2ea68c83abb1f004b"
+      sha256: "3642b184882f79e76ca57a9230fb971e494c3c1fd09c21ae3083ce891bcc0aa1"
       url: "https://pub.dev"
     source: hosted
     version: "0.5.2"
@@ -597,57 +589,57 @@ packages:
     dependency: transitive
     description:
       name: timing
-      sha256: c386d07d7f5efc613479a7c4d9d64b03710b03cfaa7e8ad5f2bfb295a1f0dfad
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "422eda09e2a50eb27fe9eca2c897d624cea7fa432a8442e1ea1a10d50a4321ab"
+      sha256: d1ba6ce3fa60807433511f943b51607bd7073f8fe5c14286d66fec8e05c8d24c
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "11.5.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "68173f2fa67d241323a4123be7ed4e43424c54befa5505d71c8ad4b7baf8f71d"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "500e6014efebd305a30ebf1c6006d13faa82dcd85c7a2a7793679a64ed69ec48"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "5adb6ab8ed14e22bb907aae7338f0c206ea21e7a27004e97664b16c120306f00"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "3cee79b1715110341012d27756d9bae38e650588acd38d3f3c610822e1337ace"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0-417 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=3.4.1 <6.0.0"
+  analyzer: ^5.12.0
   asn1lib: ^1.0.0
   bech32: ^0.2.0
   bip39: ^1.0.6
@@ -26,5 +26,5 @@ dev_dependencies:
   build_runner: ^2.1.11
   mockito: ^5.0.3
   mock_web_server: ^5.0.0-nullsafety.1
-  pedantic: ^1.11.0
   test: ^1.16.8
+  lints: ^2.1.0

--- a/test/x/auth/querier_test.dart
+++ b/test/x/auth/querier_test.dart
@@ -33,7 +33,7 @@ void main() {
       when(client.account(req)).thenAnswer((call) {
         final request = call.positionalArguments[0] as auth.QueryAccountRequest;
         final account = auth.BaseAccount.create()
-          ..address = request.address + 'wrong'
+          ..address = '${request.address}wrong'
           ..sequence = 100.toInt64()
           ..accountNumber = 101.toInt64();
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR upgrades the linting workflow inside the repository in order to use `lints` instead of `pedantic` (which is now deprecated).

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.
- [ ] Run `make format`.
- [ ] Run `make lint`.
- [ ] Updated the documentation.
- [ ] Added an entry to the `CHANGELOG.md` file.
- [ ] Re-reviewed `Files changed` in the Github PR explorer and added meaningful comments.
